### PR TITLE
chore: update Discord invite to permanent link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you need help with this template:
 - [Submit an issue](https://github.com/blaxel-templates/template-llama-index-ts/issues) for bug reports or feature requests
 - Visit the [Blaxel Documentation](https://docs.blaxel.ai) for platform guidance
 - Check the [LlamaIndex TypeScript Documentation](https://ts.llamaindex.ai/) for framework-specific help
-- Join our [Discord Community](https://discord.gg/G3NqzUPcHP) for real-time assistance
+- Join our [Discord Community](https://discord.gg/CsWKUZUHFQ) for real-time assistance
 
 ## 📄 License
 


### PR DESCRIPTION
Replaces the outdated Discord invite(s) with the new permanent, non-expiring invite: https://discord.gg/CsWKUZUHFQ
